### PR TITLE
fix: userがfirebaseに存在して，DBに存在しない場合の処理

### DIFF
--- a/server/src/Auth/routes.py
+++ b/server/src/Auth/routes.py
@@ -74,7 +74,11 @@ def signin():
     if 'error' in res:
         return jsonify({'error': res['error']['message']}), 400
 
-    users.update_one({'email': email}, {'$set': {'token': res['idToken']}})
+    if not users.find({'email': email}):
+        # firebaseにuserが存在するが、DBには存在しない場合
+        return jsonify({'error': 'User not found'}), 400
+    else:
+        users.update_one({'email': email}, {'$set': {'token': res['idToken']}})
 
     return jsonify({'token': res['idToken']}), 200
 


### PR DESCRIPTION
userがfirebaseに存在して，DBに存在しない場合，signinをpassしないように修正

## 確認事項

- [x] マージ先，マージ元のブランチは正しいですか？

- [x] mainに直接マージしようとしていませんか？

- [x] コミット，ファイルで変更点を確認しましたか？

- [x] Privateな情報が入っていないですか？


## 実装内容(変更点)

具体的な変更点や修正箇所を箇条書きでリストアップしてください。  
- userがfirebaseに存在して，DBに存在しない場合の処理
    - passしないように修正
    - error, 400を返す
